### PR TITLE
update: null check to prevent error spam

### DIFF
--- a/Moodles/Utils.cs
+++ b/Moodles/Utils.cs
@@ -142,7 +142,9 @@ public static unsafe partial class Utils
     public static AtkResNode*[] GetNodeIconArray(AtkResNode* node, bool reverse = false)
     {
         var lst = new List<nint>();
-        var uldm = node->GetAsAtkComponentNode()->Component->UldManager;
+        var atk = node->GetAsAtkComponentNode();
+        if (atk is null) return [];
+        var atk = atk->Component->UldManager;
         for (int i = 0; i < uldm.NodeListCount; i++)
         {
             var next = uldm.NodeList[i];


### PR DESCRIPTION
There is a error log spam when the `AtkResNode*` passed to the method `GetNodeIconArray` has the method `GetAsAtkComponentNode()` called and returns null thus unable to get the `Component` then `UldManager`.