### PR TITLE
Whitelist Cleanup & BugFixing

### DIFF
--- a/Moodles/Data/WhitelistEntryGSpeak.cs
+++ b/Moodles/Data/WhitelistEntryGSpeak.cs
@@ -5,31 +5,25 @@ public class WhitelistEntryGSpeak
 {
     // name of the pair that is visible and added to GSpeak
     public string PlayerName = "Unknown-Player";
-    // the types of permissions they allow our client to apply to them.
-    public List<StatusType> AllowedTypes = [];
-
-    // the max moodle duration intervals they allow our client to apply to them.
-    public int Days = 0;
-    public int Hours = 0;
-    public int Minutes = 0;
-    public int Seconds = 0;
-    
-    // if they allow permanent moodles or not.
-    public bool AnyDuration = true;
-
-    // if they allow us to apply our moodles to their client.
-    public bool CanApplyOurMoodles = false;
-
-    // if they allow us to apply their moodles to them.
-    public bool CanApplyTheirMoodles = false;
-
-    // if we can remove active moodles off them.
-    public bool CanRemoveMoodles = false;
-
+    // Allow Positive
+    // Allow Negative
+    // Allow Special
+    // Allow Applying Pairs Moodles (pair can apply moodles to you)
+    // Allow Applying Own Moodles (pair can apply your moodles)
+    // Max Duration (max duration allowed when effect is not permanent)
+    // Allow Permanent (pair can apply permanent moodles)
+    // Allow Removal (pair can remove your moodles)
     public MoodlesGSpeakPairPerms ClientPermsForPair = new();
 
-    internal long TotalMaxDurationSeconds => this.Seconds * 1000 + this.Minutes * 1000 * 60 + this.Hours * 1000 * 60 * 60 + this.Days * 1000 * 60 * 60 * 24;
-    internal long MaxExpirationUnixTimeSeconds => this.AnyDuration ? long.MaxValue : Utils.Time + TotalMaxDurationSeconds;
+    public MoodlesGSpeakPairPerms PairPermsForClient = new();
+
+    internal long TotalMaxDurationSecondsClient => this.ClientPermsForPair.MaxDuration.Seconds * 1000 + this.ClientPermsForPair.MaxDuration.Minutes * 1000 * 60
+                                                 + this.ClientPermsForPair.MaxDuration.Hours * 1000 * 60 * 60 + this.ClientPermsForPair.MaxDuration.Days * 1000 * 60 * 60 * 24;
+    internal long MaxExpirationUnixTimeSecondsClient => this.ClientPermsForPair.AllowPermanent ? long.MaxValue : Utils.Time + TotalMaxDurationSecondsClient;
+
+    internal long TotalMaxDurationSecondsPair => this.PairPermsForClient.MaxDuration.Seconds * 1000 + this.PairPermsForClient.MaxDuration.Minutes * 1000 * 60
+                                               + this.PairPermsForClient.MaxDuration.Hours * 1000 * 60 * 60 + this.PairPermsForClient.MaxDuration.Days * 1000 * 60 * 60 * 24;
+    internal long MaxExpirationUnixTimeSecondsPair => this.PairPermsForClient.AllowPermanent ? long.MaxValue : Utils.Time + TotalMaxDurationSecondsPair;
 
     // checks if when applying incoming moodles, that we have the permission to apply them.
     public bool CheckStatus(MoodlesGSpeakPairPerms status, bool statusIsPerminant)
@@ -45,35 +39,11 @@ public class WhitelistEntryGSpeak
     }
 
     public bool ArePermissionsDifferent(MoodlesGSpeakPairPerms newClientPermsForPair, MoodlesGSpeakPairPerms newPairPermsForClient)
-    {
-        return AllowedTypes.Contains(StatusType.Positive) != newPairPermsForClient.AllowPositive
-        || AllowedTypes.Contains(StatusType.Negative) != newPairPermsForClient.AllowNegative
-        || AllowedTypes.Contains(StatusType.Special) != newPairPermsForClient.AllowSpecial
-        || CanApplyOurMoodles != newPairPermsForClient.AllowApplyingPairsMoodles // this flips because the intended direction is flipped
-        || CanApplyTheirMoodles != newPairPermsForClient.AllowApplyingOwnMoodles // same as above
-        || Days != newPairPermsForClient.MaxDuration.Days
-        || Hours != newPairPermsForClient.MaxDuration.Hours
-        || Minutes != newPairPermsForClient.MaxDuration.Minutes
-        || Seconds != newPairPermsForClient.MaxDuration.Seconds
-        || AnyDuration != newPairPermsForClient.AllowPermanent
-        || CanRemoveMoodles != newPairPermsForClient.AllowRemoval
-        || !ClientPermsForPair.Equals(newClientPermsForPair);
-    }
+        => !newClientPermsForPair.Equals(ClientPermsForPair) || !newPairPermsForClient.Equals(PairPermsForClient);
 
     public void UpdatePermissions(MoodlesGSpeakPairPerms newPerms, MoodlesGSpeakPairPerms newPairPermsForClient)
     {
-        AllowedTypes = new List<StatusType>();
-        if (newPerms.AllowPositive) AllowedTypes.Add(StatusType.Positive);
-        if (newPerms.AllowNegative) AllowedTypes.Add(StatusType.Negative);
-        if (newPerms.AllowSpecial) AllowedTypes.Add(StatusType.Special);
-        CanApplyOurMoodles = newPerms.AllowApplyingPairsMoodles;
-        CanApplyTheirMoodles = newPerms.AllowApplyingOwnMoodles;
-        Days = newPerms.MaxDuration.Days;
-        Hours = newPerms.MaxDuration.Hours;
-        Minutes = newPerms.MaxDuration.Minutes;
-        Seconds = newPerms.MaxDuration.Seconds;
-        AnyDuration = newPerms.AllowPermanent;
-        CanRemoveMoodles = newPerms.AllowRemoval;
         ClientPermsForPair = newPerms;
+        PairPermsForClient = newPairPermsForClient;
     }
 }

--- a/Moodles/Gui/TabWhitelists/Tabs/GagspeakWhitelist.cs
+++ b/Moodles/Gui/TabWhitelists/Tabs/GagspeakWhitelist.cs
@@ -15,74 +15,97 @@ internal class GagspeakWhitelist : PluginWhitelist
         P.OtterGuiHandler.WhitelistGSpeak.Draw(200f);
     }
 
-    protected override void DrawHeader()
-    {
-        HeaderDrawer.Draw(Selected == null ? "GagSpeak Visible Pair Settings" : (Selected.PlayerName.Censor($"Whitelist entry {C.WhitelistGSpeak.IndexOf(Selected) + 1}")), 0, ImGui.GetColorU32(ImGuiCol.FrameBg), 0, HeaderDrawer.Button.IncognitoButton(C.Censor, v => C.Censor = v));
-    }
+     protected override void DrawHeader()
+     {
+          if (Selected == null) HeaderDrawer.Draw("GagSpeak Visible Pair Settings", 0, ImGui.GetColorU32(ImGuiCol.FrameBg), 0, HeaderDrawer.Button.IncognitoButton(C.Censor, v => C.Censor = v));
+     }
 
-    protected override void Draw()
-    {
-        using var child = ImRaii.Child("##Panel", -Vector2.One, true);
-        if (!child)
-            return;
+     protected override void Draw()
+     {
+          // if there are 0 entries in the whitelist, clear the current.
+          if (C.WhitelistGSpeak.Count == 0)
+          {
+               P.OtterGuiHandler.WhitelistGSpeak.EnsureCurrent();
+          }
 
-        // if there are 0 entries in the whitelist, clear the current.
-        if (C.WhitelistGSpeak.Count == 0)
-        {
-            P.OtterGuiHandler.WhitelistGSpeak.EnsureCurrent();
-        }
+          if (Selected == null)
+          {
+               using (var child = ImRaii.Child("##DefaultBox", -Vector2.One, true))
+               {
+                    if (!child) return;
+                    ImGuiEx.Text($"No GagSpeak Pairs are visible to view the permissions of. Select one to view permissions!");
+               }
+          }
+          else
+          {
+               HeaderDrawer.Draw("Your Permissions for " + Selected.PlayerName.Censor($"Whitelist entry {C.WhitelistGSpeak.IndexOf(Selected) + 1}"), 0, ImGui.GetColorU32(ImGuiCol.FrameBg), 0, HeaderDrawer.Button.IncognitoButton(C.Censor, v => C.Censor = v));
+               using (var child = ImRaii.Child("##Panel", new(ImGui.GetContentRegionAvail().X - 1f, ImGui.GetContentRegionAvail().Y / 2 - ImGui.GetFrameHeight()), true))
+               {
+                    if (!child) return;
 
-        if (Selected == null)
-        {
-            ImGuiEx.Text($"No GagSpeak Pairs are visible to view the permissions of. Select one to view permissions!");
-        }
-        else
-        {
-            if (ImGui.BeginTable("##wl", 2, ImGuiTableFlags.RowBg | ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.Borders))
-            {
-                ImGui.TableSetupColumn("##txt", ImGuiTableColumnFlags.WidthFixed, 150);
-                ImGui.TableSetupColumn("##inp", ImGuiTableColumnFlags.WidthStretch);
+                    DrawTableForPermissions(Selected.ClientPermsForPair, "ClientPermsForPair");
+               }
 
-                ImGui.TableNextRow();
-                ImGui.TableNextColumn();
-                ImGuiEx.TextV($"Allowed Status Types:");
-                ImGui.TableNextColumn();
+               HeaderDrawer.Draw("Permissions " + Selected.PlayerName.Censor($"Whitelist entry {C.WhitelistGSpeak.IndexOf(Selected) + 1}") + " set for You", 0, ImGui.GetColorU32(ImGuiCol.FrameBg), 0, HeaderDrawer.Button.IncognitoButton(C.Censor, v => C.Censor = v));
+               using (var child2 = ImRaii.Child("##Panel2", -Vector2.One, true))
+               {
+                    if (!child2) return;
+                    DrawTableForPermissions(Selected.PairPermsForClient, "PairPermsForClient");
+               }
+          }
+     }
 
-                ImGui.BeginDisabled();
-                foreach (var x in Enum.GetValues<StatusType>())
-                {
-                    ImGuiEx.CollectionCheckbox($"{x}", x, Selected.AllowedTypes);
-                }
-                ImGui.EndDisabled();
+     private void DrawTableForPermissions(MoodlesGSpeakPairPerms whitelistPermissionSet, string id)
+     {
+          if (ImGui.BeginTable("##wl" + id, 2, ImGuiTableFlags.RowBg | ImGuiTableFlags.SizingFixedFit | ImGuiTableFlags.Borders))
+          {
+               ImGui.TableSetupColumn("##txt" + id, ImGuiTableColumnFlags.WidthFixed, 200);
+               ImGui.TableSetupColumn("##inp" + id, ImGuiTableColumnFlags.WidthStretch);
 
-                ImGui.TableNextRow();
-                ImGui.TableNextColumn();
-                ImGuiEx.TextV($"Maximum Duration:");
-                ImGui.TableNextColumn();
+               ImGui.TableNextRow();
+               ImGui.TableNextColumn();
+               ImGuiEx.TextV($"Allowed Status Types:");
+               ImGui.TableNextColumn();
 
-                ImGui.BeginDisabled();
-                Utils.DurationSelector("Any Duration", ref Selected.AnyDuration, ref Selected.Days, ref Selected.Hours, ref Selected.Minutes, ref Selected.Seconds);
-                ImGui.EndDisabled();
+               ImGui.BeginDisabled();
+               ImGui.Checkbox("Positive##postive" + id, ref whitelistPermissionSet.AllowPositive);
+               ImGui.SameLine();
+               ImGui.Checkbox("Negative##negative" + id, ref whitelistPermissionSet.AllowNegative);
+               ImGui.SameLine();
+               ImGui.Checkbox("Special##special" + id, ref whitelistPermissionSet.AllowSpecial);
+               ImGui.EndDisabled();
 
-                ImGui.TableNextRow();
-                ImGui.TableNextColumn();
-                ImGuiEx.TextV($"Apply Direction:");
-                ImGui.TableNextColumn();
+               ImGui.TableNextRow();
+               ImGui.TableNextColumn();
+               ImGuiEx.TextV($"Maximum Duration:");
+               ImGui.TableNextColumn();
 
-                ImGui.BeginDisabled();
-                ImGui.Checkbox("Can Apply Our Moodles", ref Selected.CanApplyOurMoodles);
-                ImGui.Checkbox("Can Apply Their Moodles", ref Selected.CanApplyTheirMoodles);
-                ImGui.EndDisabled();
+               ImGui.BeginDisabled();
+               int days = whitelistPermissionSet.MaxDuration.Days;
+               int hours = whitelistPermissionSet.MaxDuration.Hours;
+               int minutes = whitelistPermissionSet.MaxDuration.Minutes;
+               int seconds = whitelistPermissionSet.MaxDuration.Seconds;
+               Utils.DurationSelector("Any Duration", ref whitelistPermissionSet.AllowPermanent, ref days, ref hours, ref minutes, ref seconds);
+               ImGui.EndDisabled();
 
-                ImGui.TableNextRow();
-                ImGui.TableNextColumn();
-                ImGuiEx.TextV($"Status Removal:");
-                ImGui.TableNextColumn();
-                ImGui.BeginDisabled();
-                ImGui.Checkbox("Can Remove Moodles", ref Selected.CanRemoveMoodles);
-                ImGui.EndDisabled();
-                ImGui.EndTable();
-            }
-        }
-    }
+               ImGui.TableNextRow();
+               ImGui.TableNextColumn();
+               ImGuiEx.TextV($"Apply Direction:");
+               ImGui.TableNextColumn();
+
+               ImGui.BeginDisabled();
+               ImGui.Checkbox("Can Apply Our Moodles##" + id, ref whitelistPermissionSet.AllowApplyingOwnMoodles);
+               ImGui.Checkbox("Can Apply Their Moodles##" + id, ref whitelistPermissionSet.AllowApplyingPairsMoodles);
+               ImGui.EndDisabled();
+
+               ImGui.TableNextRow();
+               ImGui.TableNextColumn();
+               ImGuiEx.TextV($"Status Removal:");
+               ImGui.TableNextColumn();
+               ImGui.BeginDisabled();
+               ImGui.Checkbox("Can Remove Moodles##" + id, ref whitelistPermissionSet.AllowRemoval);
+               ImGui.EndDisabled();
+               ImGui.EndTable();
+          }
+     }
 }

--- a/Moodles/OtterGuiHandlers/Whitelist/GSpeak/WhitelistGSpeak.cs
+++ b/Moodles/OtterGuiHandlers/Whitelist/GSpeak/WhitelistGSpeak.cs
@@ -34,58 +34,39 @@ public class WhitelistGSpeak : WhitelistItemSelectorGSpeak<WhitelistEntryGSpeak>
         return p != null && !p.PlayerName.Contains(Filter, StringComparison.OrdinalIgnoreCase);
     }
 
-    public static void SyncWithGSpeakPlayers(List<(string, MoodlesGSpeakPairPerms, MoodlesGSpeakPairPerms)> gSpeakPlayers)
-    {
-        var currentNames = C.WhitelistGSpeak.Select(entry => entry.PlayerName).ToList();
-        // Add new names to the whitelist
-        var newEntries = gSpeakPlayers
-            .Where(player => !currentNames.Contains(player.Item1))
-            .Select(player =>
-            {
-                var perms = player.Item3;
-                var allowedTypes = new[]
-                {
-                    (perms.AllowPositive, StatusType.Positive),
-                    (perms.AllowNegative, StatusType.Negative),
-                    (perms.AllowSpecial, StatusType.Special)
-                }
-                .Where(t => t.Item1)
-                .Select(t => t.Item2)
-                .ToList();
+     public static void SyncWithGSpeakPlayers(List<(string, MoodlesGSpeakPairPerms, MoodlesGSpeakPairPerms)> gSpeakPlayers)
+     {
+          var currentNames = C.WhitelistGSpeak.Select(entry => entry.PlayerName).ToList();
+          // Add new names to the whitelist
+          var newEntries = gSpeakPlayers
+              .Where(player => !currentNames.Contains(player.Item1) && !player.Item1.IsNullOrEmpty())
+              .Select(player =>
+              {
+                   return new WhitelistEntryGSpeak
+                   {
+                        PlayerName = player.Item1,
+                        ClientPermsForPair = player.Item2,
+                        PairPermsForClient = player.Item3
+                   };
+              })
+              .ToList();
+          // Add the entry range to the whitelist
+          C.WhitelistGSpeak.AddRange(newEntries);
 
-                return new WhitelistEntryGSpeak
-                {
-                    PlayerName = player.Item1,
-                    AllowedTypes = allowedTypes,
-                    CanApplyOurMoodles = perms.AllowApplyingPairsMoodles,
-                    CanApplyTheirMoodles = perms.AllowApplyingOwnMoodles,
-                    Days = perms.MaxDuration.Days,
-                    Hours = perms.MaxDuration.Hours,
-                    Minutes = perms.MaxDuration.Minutes,
-                    Seconds = perms.MaxDuration.Seconds,
-                    AnyDuration = perms.AllowPermanent,
-                    CanRemoveMoodles = perms.AllowRemoval,
-                    ClientPermsForPair = player.Item2
-                };
-            })
-            .ToList();
-        // Add the entry range to the whitelist
-        C.WhitelistGSpeak.AddRange(newEntries);
+          // Update names already present if their permissions do not match
+          C.WhitelistGSpeak
+              .Where(entry => gSpeakPlayers.Any(player => player.Item1 == entry.PlayerName))
+              .ToList()
+              .ForEach(entry =>
+              {
+                   var perms = gSpeakPlayers.First(player => player.Item1 == entry.PlayerName);
+                   if (entry.ArePermissionsDifferent(perms.Item2, perms.Item3))
+                   {
+                        entry.UpdatePermissions(perms.Item2, perms.Item3);
+                   }
+              });
 
-        // Update names already present if their permissions do not match
-        C.WhitelistGSpeak
-            .Where(entry => gSpeakPlayers.Any(player => player.Item1 == entry.PlayerName))
-            .ToList()
-            .ForEach(entry =>
-            {
-                var perms = gSpeakPlayers.First(player => player.Item1 == entry.PlayerName);
-                if (entry.ArePermissionsDifferent(perms.Item2, perms.Item3))
-                {
-                    entry.UpdatePermissions(perms.Item2, perms.Item3);
-                }
-            });
-
-        // Remove names that are no longer in the GSpeakPlayers list
-        C.WhitelistGSpeak.RemoveAll(entry => !gSpeakPlayers.Any(player => player.Item1 == entry.PlayerName));
-    }
+          // Remove names that are no longer in the GSpeakPlayers list
+          C.WhitelistGSpeak.RemoveAll(entry => !gSpeakPlayers.Any(player => player.Item1 == entry.PlayerName));
+     }
 }

--- a/Moodles/Utils.cs
+++ b/Moodles/Utils.cs
@@ -109,7 +109,6 @@ public static unsafe partial class Utils
 
     public static bool CheckWhitelistGlobal(MyStatus status)
     {
-        if (status.ExpiresAt > C.BroadcastDefaultEntry.MaxExpirationUnixTimeSeconds) return false;
         if (C.BroadcastAllowAll) return true;
         if (C.BroadcastAllowParty) return UniversalParty.Members.Any(x => x.Name == status.Applier);
         if (C.BroadcastAllowFriends) return GetFriendlist().Contains(status.Applier);


### PR DESCRIPTION
Displays Both ClientPermissionsForPair and PairPermissionsForClient, and now properly updated on permission changes so application to targets permission checks are properly updated.

Also cleaned up the whitelist entry a lot by keeping things in tuples instead for easier checking.