### PR TITLE
Added a GetStatusManagerInfo method to IPC & Finished IPC Processor Documentation.

### DIFF
--- a/Moodles/MyStatusManager.cs
+++ b/Moodles/MyStatusManager.cs
@@ -120,6 +120,12 @@ public class MyStatusManager
         return Convert.ToBase64String(BinarySerialize());
     }
 
+    public List<MoodlesStatusInfo> GetActiveStatusInfo()
+    {
+        if (this.Statuses.Count == 0) return new List<MoodlesStatusInfo>();
+        return this.Statuses.Select(x => x.ToStatusInfoTuple()).ToList();
+    }
+
     public void Apply(byte[] data) => SetStatusesAsEphemeral(MemoryPackSerializer.Deserialize<List<MyStatus>>(data));
 
     public void Apply(string base64string)


### PR DESCRIPTION
### Added a GetStatusManagerInfo method to IPC & Finished IPC Processor Documentation.

Hopefully the last pull request I'll need to make for awhile.

This adds additional IPC for fetching the MoodleStatusInfo tuple format from a StatusManagers stored Statuses.
**The original GetStatusManager is untouched.** 
This allows other plugins to more easily view the contents of fetched status managers if they need, without having to deserialize the status manager every time it is changed, and also makes it so plugins to not need to include memorypackserializer in their plugins if they already use a different serialization packer.

Additionally, Documentation on IPCProcessor is now finished.