### PR TITLE
Add Stacking Moodles for Moodles that have a stackable counter.

### DIFF
--- a/Moodles/Data/MyStatus.cs
+++ b/Moodles/Data/MyStatus.cs
@@ -17,6 +17,8 @@ public partial class MyStatus
     public int Stacks = 1;
     public Guid StatusOnDispell = Guid.Empty;
     public string CustomFXPath = "";
+    public bool StackOnReapply = false;
+
 
     [MemoryPackIgnore] public bool Persistent = false;
 
@@ -74,7 +76,7 @@ public partial class MyStatus
     }
 
     public MoodlesStatusInfo ToStatusInfoTuple()
-        => (GUID, IconID, Title, Description, Type, Applier, Dispelable, Stacks, Persistent, Days, Hours, Minutes, Seconds, NoExpire, AsPermanent, StatusOnDispell, CustomFXPath);
+        => (GUID, IconID, Title, Description, Type, Applier, Dispelable, Stacks, Persistent, Days, Hours, Minutes, Seconds, NoExpire, AsPermanent, StatusOnDispell, CustomFXPath, StackOnReapply);
 
     public static MyStatus FromStatusInfoTuple(MoodlesStatusInfo statusInfo)
     {
@@ -96,7 +98,8 @@ public partial class MyStatus
             NoExpire = statusInfo.NoExpire,
             AsPermanent = statusInfo.AsPermanent,
             StatusOnDispell = statusInfo.StatusOnDispell,
-            CustomFXPath = statusInfo.CustomVFXPath
+            CustomFXPath = statusInfo.CustomVFXPath,
+            StackOnReapply = statusInfo.StackOnReapply
         };
     }
 }

--- a/Moodles/IPCTypedef.cs
+++ b/Moodles/IPCTypedef.cs
@@ -31,7 +31,8 @@ global using MoodlesStatusInfo = (
     bool NoExpire,
     bool AsPermanent,
     System.Guid StatusOnDispell,
-    string CustomVFXPath
+    string CustomVFXPath,
+    bool StackOnReapply
 );
 
 


### PR DESCRIPTION
Overview of Changes:
-> Reorder of the Moodle Status Editor UI to be more categorized.
The new Order arranges it so you see in order:

- Title
- Icon & Icon Application
- Description
- Type
- Additional Parameter Options
- Applier
- ID

(Also changed "Dispellable" to "Imply Dispellable" since so many people that use Moodles have thought it means you can actually dispel them with Esuna when you cant)

-> Added "StackOnReapply" to the end of the MyStatus class, with no rearrangements to tuple order or class order to avoid breaking MemoryPack Changes (Thanks Limiana for the feedback on this)
-> StatusManager during its core .AddOrUpdate method now when updating a moodle, will also check if maxStacks > 1. 
If it is, it will take the current stack count in the status manager, and store it into the newStatus incoming +1, before updating it with that information, allowing it to stack.
-> StatusManager will remove the GUID from the AddTextShown GUID Hashset List to make it so the new stack counts apply text is displayed on the next tick to inform us it has been updated.

This allows the status manager to update without affecting the original MyStatus object in or storage, so if at any point the StackOnReapply is disabled, it will automatically revert to the pre-defined stack count. 