### PR TITLE
Added UpdateSource to status manager AddOrUpdate to determine if the update is a full data update or individual reapplication for compatibility with any "on reapply" functionality

### DIFF
--- a/Moodles/Commands/MoodleCommandProcessor.cs
+++ b/Moodles/Commands/MoodleCommandProcessor.cs
@@ -142,7 +142,7 @@ public static class MoodleCommandProcessor
                 }
                 else
                 {
-                    statusManager.AddOrUpdate(myStatus.PrepareToApply(myStatus.Persistent ? PrepareOptions.Persistent : PrepareOptions.NoOption));
+                    statusManager.AddOrUpdate(myStatus.PrepareToApply(myStatus.Persistent ? PrepareOptions.Persistent : PrepareOptions.NoOption), UpdateSource.StatusTuple);
                 }
             }
             else if (moodleState == MoodleState.Remove)

--- a/Moodles/Data/Preset.cs
+++ b/Moodles/Data/Preset.cs
@@ -6,5 +6,8 @@ public class Preset
     public Guid GUID = Guid.NewGuid();
     public List<Guid> Statuses = [];
     public PresetApplicationType ApplicationType = PresetApplicationType.UpdateExisting;
+    public string Title = "";
     public bool ShouldSerializeGUID() => GUID != Guid.Empty;
+
+    public MoodlePresetInfo ToPresetInfoTuple() => (GUID, Statuses, ApplicationType, Title);
 }

--- a/Moodles/Data/UpdateType.cs
+++ b/Moodles/Data/UpdateType.cs
@@ -1,0 +1,12 @@
+﻿namespace Moodles.Data;
+
+/// <summary>
+/// Determines how the status manager should add/update a status upon application.
+/// </summary>
+public enum UpdateSource
+{
+    // From full manager updates. These should ignore stackOnReapply, as they are updates, not reapplications.
+    DataString,
+    // From Applications or Reapplications. These should respect other "on reapply" settings.
+    StatusTuple,
+}

--- a/Moodles/GameGuiProcessors/CommonProcessor.cs
+++ b/Moodles/GameGuiProcessors/CommonProcessor.cs
@@ -138,7 +138,7 @@ public unsafe class CommonProcessor : IDisposable
                     {
                         if (status.GUID != x.Status.StatusOnDispell) continue;
 
-                        x.StatusManager.AddOrUpdate(status.PrepareToApply(status.Persistent ? PrepareOptions.Persistent : PrepareOptions.NoOption));
+                        x.StatusManager.AddOrUpdate(status.PrepareToApply(status.Persistent ? PrepareOptions.Persistent : PrepareOptions.NoOption), UpdateSource.StatusTuple);
                     }
                 }
             }

--- a/Moodles/Gui/TabMoodles.cs
+++ b/Moodles/Gui/TabMoodles.cs
@@ -37,7 +37,7 @@ public static class TabMoodles
             var cur = new Vector2(ImGui.GetCursorPosX() + ImGui.GetContentRegionAvail().X - UI.StatusIconSize.X * 2, ImGui.GetCursorPosY()) - new Vector2(10, 0);
             if(ImGui.Button("Apply to Yourself"))
             {
-                Utils.GetMyStatusManager(Player.NameWithWorld).AddOrUpdate(Selected.PrepareToApply(AsPermanent ? PrepareOptions.Persistent : PrepareOptions.NoOption));
+                Utils.GetMyStatusManager(Player.NameWithWorld).AddOrUpdate(Selected.PrepareToApply(AsPermanent ? PrepareOptions.Persistent : PrepareOptions.NoOption), UpdateSource.StatusTuple);
             }
             ImGui.SameLine();
 
@@ -55,7 +55,7 @@ public static class TabMoodles
                     var target = (IPlayerCharacter)Svc.Targets.Target;
                     if(!isMare)
                     {
-                        Utils.GetMyStatusManager(target.GetNameWithWorld()).AddOrUpdate(Selected.PrepareToApply(AsPermanent ? PrepareOptions.Persistent : PrepareOptions.NoOption));
+                        Utils.GetMyStatusManager(target.GetNameWithWorld()).AddOrUpdate(Selected.PrepareToApply(AsPermanent ? PrepareOptions.Persistent : PrepareOptions.NoOption), UpdateSource.StatusTuple);
                     }
                     else
                     {

--- a/Moodles/Gui/TabPresets.cs
+++ b/Moodles/Gui/TabPresets.cs
@@ -79,10 +79,17 @@ public static class TabPresets
             }
             if(dis) ImGui.EndDisabled();
 
-            ImGuiEx.TextV("On application:");
-            ImGui.SameLine();
-            ImGuiEx.SetNextItemFullWidth();
-            if(ImGuiEx.EnumCombo("##on", ref Selected.ApplicationType, ApplicationTypes))
+            ImGui.Separator();
+
+            ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X - 150);
+            ImGui.InputTextWithHint("Rename Preset", "Give preset a name", ref Selected.Title, 100, C.Censor ? ImGuiInputTextFlags.Password : ImGuiInputTextFlags.None);
+            if(ImGui.IsItemDeactivatedAfterEdit())
+            {
+                P.IPCProcessor.PresetModified(Selected.GUID);
+            }
+
+            ImGui.SetNextItemWidth(ImGui.GetContentRegionAvail().X - 150);
+            if (ImGuiEx.EnumCombo("Application Effect##on", ref Selected.ApplicationType, ApplicationTypes))
             {
                 P.IPCProcessor.PresetModified(Selected.GUID);
             }

--- a/Moodles/Gui/UI.cs
+++ b/Moodles/Gui/UI.cs
@@ -320,7 +320,7 @@ public static unsafe class UI
                     Status.GUID = Guid.NewGuid();
                     Status.ExpiresAt = Utils.Time + Duration * 1000;
                     if(Duration == 0) Status.ExpiresAt = long.MaxValue;
-                    manager.AddOrUpdate(Status.JSONClone());
+                    manager.AddOrUpdate(Status.JSONClone(), UpdateSource.StatusTuple);
                 }
                 ImGui.SameLine();
                 if(ImGui.Button("Randomize and add"))
@@ -333,7 +333,7 @@ public static unsafe class UI
                     Status.Seconds = Random.Shared.Next(5, 60);
                     if(Random.Shared.Next(20) == 0) Status.Minutes = Random.Shared.Next(5, 60);
                     if(Random.Shared.Next(100) == 0) Status.Hours = Random.Shared.Next(5, 60);
-                    manager.AddOrUpdate(Status.JSONClone().PrepareToApply());
+                    manager.AddOrUpdate(Status.JSONClone().PrepareToApply(), UpdateSource.StatusTuple);
                 }
                 ImGui.SameLine();
                 ImGui.SetNextItemWidth(100f);
@@ -355,7 +355,7 @@ public static unsafe class UI
                         if(Random.Shared.Next(20) == 0) Status.Minutes = Random.Shared.Next(5, 60);
                         if(Random.Shared.Next(100) == 0) Status.Hours = Random.Shared.Next(5, 60);
                         var array = Svc.Objects.Where(x => x is IPlayerCharacter pc && pc.IsTargetable).Cast<IPlayerCharacter>().ToArray();
-                        Utils.GetMyStatusManager(array[Random.Shared.Next(array.Length)]).AddOrUpdate(Status.JSONClone().PrepareToApply());
+                        Utils.GetMyStatusManager(array[Random.Shared.Next(array.Length)]).AddOrUpdate(Status.JSONClone().PrepareToApply(), UpdateSource.StatusTuple);
                     }
                 }
                 ImGui.SameLine();
@@ -366,7 +366,7 @@ public static unsafe class UI
                 ImGui.SameLine();
                 if(ImGui.Button("Apply bin") && TryParseByteArray(Paste(), out var a))
                 {
-                    manager.Apply(a);
+                    manager.Apply(a, UpdateSource.DataString);
                 }
                 ImGui.Separator();
             }

--- a/Moodles/IPCTypedef.cs
+++ b/Moodles/IPCTypedef.cs
@@ -35,4 +35,11 @@ global using MoodlesStatusInfo = (
     bool StackOnReapply
 );
 
+global using MoodlePresetInfo = (
+    System.Guid GUID,
+    System.Collections.Generic.List<System.Guid> Statuses,
+    Moodles.Data.PresetApplicationType ApplicationType,
+    string Title
+);
+
 


### PR DESCRIPTION
- Added Preset Titles
- Added PresetInfoTuple instead of the makeshift tuple used for presets with GagSpeak original for a more organized approach.
- Added the UpdateSource so that any sets and updates to the status manager with string data that is not from an individual Guid will not trigger stack on reapply, but instead maintain the same number of stacks currently present.

GagSpeak is currently the only Plugin using this TupleInfo dependency, and I am its developer, so I'm fine with this change.
(Also Updated ECommons because why not)
