### PR TITLE
Add TryOnMoodleStatus IPCEvent Method for compatibility with new Moodles ShareHub

### DIFF
--- a/Moodles/IPCProcessor.cs
+++ b/Moodles/IPCProcessor.cs
@@ -83,6 +83,26 @@ public class IPCProcessor : IDisposable
         });
     }
 
+    /// <summary>
+    /// Only called upon by GagSpeak to apply a status to the client player via a status Tuple.
+    /// This is appended as a GagSpeak. Event to prevent exploitive bypass of whitelist permissions required otherwise.
+    /// 
+    /// All calls made from this with GagSpeak are for the purpose of "trying on" Moodles downloaded 
+    /// from a database holding Moodle Statuses to share with others.
+    /// </summary>
+    [EzIPCEvent("GagSpeak.TryOnMoodleStatus", false)]
+    private void TryOnMoodleStatus(MoodlesStatusInfo status)
+    {
+        new TickScheduler(() =>
+        {
+            PluginLog.LogDebug($"GagSpeak is applying status {status.Title} to client");
+            if (Player.Object is null) return;
+            // grab our players status manager.
+            var sm = Utils.GetMyStatusManager(Player.Object);
+            sm.AddOrUpdate(MyStatus.FromStatusInfoTuple(status).PrepareToApply(), UpdateSource.StatusTuple, false, true);
+        });
+    }
+
     public IPCProcessor()
     {
         EzIPC.Init(this);


### PR DESCRIPTION
I've decided to start hosting a subset of tables in my Server's Database Dedicated to allowing people to upload their MoodleStatuses they have created, for others to browse, copy for Moodles import, and rate.

To add to this functionality, I thought it would be a nice idea to add a "Try On Feature" where you can hit a button, and it would send off that search results tuple off to Moodles to apply to the client player so they could see how it looked in game.

To deal with the glaringly obvious issue of IPC Calls that apply tuples being exploited by its ability to bypass whitelist permissions, I've opted to call it directly from GSpeak's IPC Provider instead of as a generic Method in Moodles, so this way GSpeak is the only plugin able to call this method to ensure permission safety remains in place. ❤️ 

( I Didn't adjust the .csproj version incase it would mess with the Github actions bot somehow.)