### PR TITLE
fix lingering moodles when IPC owner stops being rendered

### DIFF
--- a/Moodles/GameGuiProcessors/CommonProcessor.cs
+++ b/Moodles/GameGuiProcessors/CommonProcessor.cs
@@ -117,6 +117,9 @@ public unsafe class CommonProcessor : IDisposable
     {
         // List of VFX that should be handled by the StatusHitEffect.
         List<(nint PlayerAddr, string customPath)> SHECandidates = [];
+        List<string>? toAutoClean = null;
+        // Null during zone transitions. Skip cleanup to avoid false removals while pointers are stale.
+        var localPlayerName = LocalPlayer.Available ? LocalPlayer.NameWithWorld : null;
 
         if (HoveringOver != 0)
         {
@@ -198,6 +201,27 @@ public unsafe class CommonProcessor : IDisposable
                             $"One of your Plugins may have outdated IPC parameters for this IPCEvent");
                     }
                 }
+            }
+
+            // Safety net for empty non-rendered SMs that CharaWatcher didn't catch.
+            var isLocalPlayer = localPlayerName != null && ownerNameWorld == localPlayerName;
+
+            if (localPlayerName != null
+                && !isLocalPlayer
+                && !sm.OwnerValid
+                && sm.Statuses.Count == 0)
+            {
+                toAutoClean ??= [];
+                toAutoClean.Add(ownerNameWorld);
+            }
+        }
+
+        if (toAutoClean != null)
+        {
+            foreach (var key in toAutoClean)
+            {
+                PluginLog.Debug($"Auto-cleaning lingering ephemeral status manager for {key}");
+                C.StatusManagers.Remove(key);
             }
         }
 

--- a/Moodles/GameHelpers/CharaWatcher.cs
+++ b/Moodles/GameHelpers/CharaWatcher.cs
@@ -182,12 +182,12 @@ public unsafe class CharaWatcher : IDisposable
                         sm.Owner = null;
                     }
 
-                    // If Ephemeral, remove their status manager and any SeenPlayers entry.
-                    if (sm.Ephemeral)
+                    // IPC-managed SMs are removed on leave so dead syncs don't linger.
+                    if (sm.Ephemeral || sm.LastSyncUpdate > 0)
                     {
                         C.StatusManagers.Remove(charaNameWorld);
                         P.SeenPlayers.RemoveAll(x => x.Name == charaNameWorld);
-                        PluginLog.Debug($"Removing ephemeral status manager for {charaNameWorld}");
+                        PluginLog.Debug($"Removing {(sm.Ephemeral ? "ephemeral" : "IPC-managed")} status manager for {charaNameWorld}");
                     }
                 }
             }

--- a/Moodles/GameHelpers/CharaWatcher.cs
+++ b/Moodles/GameHelpers/CharaWatcher.cs
@@ -183,7 +183,7 @@ public unsafe class CharaWatcher : IDisposable
                     }
 
                     // IPC-managed SMs are removed on leave so dead syncs don't linger.
-                    if (sm.Ephemeral || sm.LastSyncUpdate > 0)
+                    if (sm.Ephemeral || sm.WasTouchedByIPC)
                     {
                         C.StatusManagers.Remove(charaNameWorld);
                         P.SeenPlayers.RemoveAll(x => x.Name == charaNameWorld);

--- a/Moodles/Gui/TabFuckup.cs
+++ b/Moodles/Gui/TabFuckup.cs
@@ -25,6 +25,7 @@ public static unsafe class TabFuckup
         {
             foreach (var x in C.StatusManagers)
             {
+                if (x.Value.Statuses.Count == 0) continue;
                 if (ImGui.Selectable(x.Key))
                 {
                     OwnerNameWorld = x.Key;

--- a/Moodles/Gui/TabSettings.cs
+++ b/Moodles/Gui/TabSettings.cs
@@ -33,5 +33,6 @@ public static class TabSettings
         ImGui.Checkbox($"Others can Esuna Moodles", ref C.OthersCanEsunaMoodles);
 
         ImGui.Checkbox($"Allow other plugins apply Moodles.", ref C.AllowRemoteApply);
+
     }
 }

--- a/Moodles/IPCProcessor.cs
+++ b/Moodles/IPCProcessor.cs
@@ -67,7 +67,7 @@ public class IPCProcessor : IDisposable
     {
         var chara = (Character*)charaAddr;
         if (chara == null) return;
-        chara->MyStatusManager().LastSyncUpdate = Utils.Time;
+        chara->MyStatusManager().WasTouchedByIPC = true;
     }
 
     #region StatusManager

--- a/Moodles/IPCProcessor.cs
+++ b/Moodles/IPCProcessor.cs
@@ -63,6 +63,13 @@ public class IPCProcessor : IDisposable
         return 4;
     }
 
+    private unsafe void MarkSynced(nint charaAddr)
+    {
+        var chara = (Character*)charaAddr;
+        if (chara == null) return;
+        chara->MyStatusManager().LastSyncUpdate = Utils.Time;
+    }
+
     #region StatusManager
     [EzIPC("ClearStatusManagerByNameV2")]
     private unsafe void ClearStatusManager(string name)
@@ -88,6 +95,7 @@ public class IPCProcessor : IDisposable
     /// </summary>
     private unsafe void ClearStatusManagerInternal(nint charaAddr)
     {
+        MarkSynced(charaAddr);
         Character* chara = (Character*)charaAddr;
         if (chara == null)
         {
@@ -130,6 +138,7 @@ public class IPCProcessor : IDisposable
     /// </summary>
     private unsafe void SetStatusManagerInternal(nint charaAddr, string data)
     {
+        MarkSynced(charaAddr);
         Character* chara = (Character*)charaAddr;
         if (chara == null)
         {
@@ -292,10 +301,16 @@ public class IPCProcessor : IDisposable
     /// </summary>
     private unsafe void AddOrUpdateMoodleInternal(nint charaAddr, Guid guid)
     {
+        MarkSynced(charaAddr);
         Character* chara = (Character*)charaAddr;
         if (chara == null)
         {
             PluginLog.LogWarning("[IPC] AddOrUpdate Moodle Chara is NULL");
+            return;
+        }
+        if (!C.AllowRemoteApply)
+        {
+            PluginLog.LogWarning("[IPC] received apply request but remote apply is not enabled.");
             return;
         }
         if (C.SavedStatuses.TryGetFirst(x => x.GUID == guid, out var status))
@@ -333,6 +348,7 @@ public class IPCProcessor : IDisposable
     /// </summary>
     private unsafe void AddOrUpdateMoodleInternal(nint charaAddr, MoodlesStatusInfo data)
     {
+        MarkSynced(charaAddr);
         Character* chara = (Character*)charaAddr;
         if (chara == null)
         {
@@ -376,6 +392,7 @@ public class IPCProcessor : IDisposable
     /// </summary>
     private unsafe void ApplyPresetInternal(nint charaAddr, Guid guid)
     {
+        MarkSynced(charaAddr);
         Character* chara = (Character*)charaAddr;
         if (chara == null)
         {
@@ -400,6 +417,7 @@ public class IPCProcessor : IDisposable
     /// </summary>
     private unsafe void RemoveMoodleInternal(nint charaAddr, Guid guid)
     {
+        MarkSynced(charaAddr);
         Character* chara = (Character*)charaAddr;
         var sm = chara->MyStatusManager();
 
@@ -441,6 +459,7 @@ public class IPCProcessor : IDisposable
     /// </summary>
     private unsafe void RemoveMoodlesInternal(nint charaAddr, List<Guid> guids)
     {
+        MarkSynced(charaAddr);
         Character* chara = (Character*)charaAddr;
         if (chara == null)
         {
@@ -468,6 +487,7 @@ public class IPCProcessor : IDisposable
 
     private unsafe void RemovePresetInternal(nint charaAddr, Guid guid)
     {
+        MarkSynced(charaAddr);
         Character* chara = (Character*)charaAddr;
         if (chara == null)
         {

--- a/Moodles/Moodles.cs
+++ b/Moodles/Moodles.cs
@@ -59,6 +59,7 @@ public class Moodles : IDalamudPlugin
             EzConfigGui.Window.SetMinSize(800, 500);
             //EzConfigGui.Open();
             CleanupStatusManagers();
+            PurgeEphemeralManagers();
             new EzTerritoryChanged((x) => CleanupStatusManagers());
             IPCProcessor = new();
             IPCTester = new();
@@ -84,6 +85,18 @@ public class Moodles : IDalamudPlugin
             if(m.Statuses.Count == 0 && !m.OwnerValid)
             {
                 PluginLog.Debug($"  Deleting empty status manager for {x}");
+                C.StatusManagers.Remove(x);
+            }
+        }
+    }
+
+    public void PurgeEphemeralManagers()
+    {
+        foreach(var x in C.StatusManagers.Keys.ToArray())
+        {
+            if(C.StatusManagers[x].Ephemeral)
+            {
+                PluginLog.Debug($"  Purging ephemeral status manager for {x}");
                 C.StatusManagers.Remove(x);
             }
         }
@@ -130,21 +143,6 @@ public class Moodles : IDalamudPlugin
                 ApplyAutomation();
             }
 
-            // Need this Tick() check because someone could become a Sundouleia user after being rendered.
-            foreach (Character* chara in CharaWatcher.Rendered)
-            {
-                if (chara == LocalPlayer.Character) continue;
-
-                if (chara->MyStatusManager() is { } sm)
-                {
-                    if (sm.Ephemeral)
-                    {
-                        PluginLog.Debug($"{chara->GetNameWithWorld()} Sundouleia player removed from rendering. Cleaning up ephemeral status manager.");
-                        // Mark them as no longer Ephemeral.
-                        sm.Ephemeral = false;
-                    }
-                }
-            }
         }
         if(CanModifyUI())
         {
@@ -248,6 +246,7 @@ public class Moodles : IDalamudPlugin
 
     public void Dispose()
     {
+        Safe(() => PurgeEphemeralManagers());
         Safe(() => CleanupStatusManagers());
         Safe(() => IPCProcessor?.Dispose());
         Safe(() => CommonProcessor?.Dispose());

--- a/Moodles/MyStatusManager.cs
+++ b/Moodles/MyStatusManager.cs
@@ -15,7 +15,7 @@ public class MyStatusManager
     public HashSet<Guid> RemTextShown = [];
     public List<MyStatus> Statuses = [];
     public bool Ephemeral = false;
-    public long LastSyncUpdate = 0;
+    public bool WasTouchedByIPC = false;
 
     // Used by GSpeak, exclusive to the Client's StatusManager.
     // Helps prevent right-click off from working on these

--- a/Moodles/MyStatusManager.cs
+++ b/Moodles/MyStatusManager.cs
@@ -15,6 +15,7 @@ public class MyStatusManager
     public HashSet<Guid> RemTextShown = [];
     public List<MyStatus> Statuses = [];
     public bool Ephemeral = false;
+    public long LastSyncUpdate = 0;
 
     // Used by GSpeak, exclusive to the Client's StatusManager.
     // Helps prevent right-click off from working on these


### PR DESCRIPTION
## Problem
ipc-applied status managers never got cleared when their source character stopped being rendered. other players kept seeing moodles after the owner disabled the plugin cleared their moodles or left a sync

## Cause
three things

first `CharaWatcher.RemoveCharacter` only set `sm.Owner = null` when a character left render. the StatusManager stayed in `C.StatusManagers` with all its statuses so moodles kept rendering on observers until a zone change wiped them

second `Moodles.cs Tick()` had a leftover block from the old Sundouleia integration. commit 6965de6 added it with two branches then commit 79dcd0a removed the Sundouleia specific path but left the else branch in place. it was unconditionally resetting `sm.Ephemeral = false` on every rendered character every frame which killed the whole Ephemeral cleanup path

third the `AddOrUpdateMoodle(nint Guid)` overload didn't check `C.AllowRemoteApply` before applying while the other overload did. so moodles got re-applied through the Guid path on every render even with remote apply off

## Fix
- added a `LastSyncUpdate` timestamp on `MyStatusManager` stamped via a `MarkSynced()` helper in every IPC entry (`ClearStatusManager` `SetStatusManager` both `AddOrUpdateMoodle` overloads `ApplyPreset` `RemoveMoodle` `RemoveMoodles` `RemovePreset`)
- `CharaWatcher.RemoveCharacter` now removes any StatusManager that is either `Ephemeral` or has `LastSyncUpdate > 0` when its owner leaves render
- added a LocalPlayer guard so third party IPC can't wipe the local user's own SM
- fixed `AddOrUpdateMoodle(nint Guid)` to honor `AllowRemoteApply`
- removed the dead Tick block now that Sundouleia uses the generic IPC path like every other sync plugin
- safety net in `CommonProcessor` to drop owner-less empty SMs
- `TabFuckup` dropdown now filters out SMs with no active moodles so the list stays readable

## Scenarios tested
- pause a player in Lightl and Psync their moodles clear after they leave render
- disable Moodles on player B player A stops seeing B's moodles
- player removes all their moodles clears on observers
- re-sync after disconnect moodles re-apply cleanly via IPC