### PR TITLE
Permissions Changes for IPCs

### DIFF
--- a/Moodles/IPCProcessor.cs
+++ b/Moodles/IPCProcessor.cs
@@ -301,26 +301,9 @@ public class IPCProcessor : IDisposable
     /// </summary>
     private unsafe void AddOrUpdateMoodleInternal(nint charaAddr, Guid guid)
     {
-        MarkSynced(charaAddr);
-        Character* chara = (Character*)charaAddr;
-        if (chara == null)
-        {
-            PluginLog.LogWarning("[IPC] AddOrUpdate Moodle Chara is NULL");
-            return;
-        }
-        if (!C.AllowRemoteApply)
-        {
-            PluginLog.LogWarning("[IPC] received apply request but remote apply is not enabled.");
-            return;
-        }
         if (C.SavedStatuses.TryGetFirst(x => x.GUID == guid, out var status))
         {
-            var sm = chara->MyStatusManager();
-            if (!sm.Ephemeral)
-            {
-                PluginLog.LogDebug($"Adding or Updating Moodle {status.Title} to {chara->GetNameWithWorld()}");
-                sm.AddOrUpdate(status.PrepareToApply(), UpdateSource.StatusTuple, false, true);
-            }
+            AddOrUpdateMoodleInternal(charaAddr, status);
         }
     }
     
@@ -348,6 +331,12 @@ public class IPCProcessor : IDisposable
     /// </summary>
     private unsafe void AddOrUpdateMoodleInternal(nint charaAddr, MoodlesStatusInfo data)
     {
+        var status = MyStatus.FromTuple(data);
+        AddOrUpdateMoodleInternal(charaAddr, status);
+    }
+
+    private unsafe void AddOrUpdateMoodleInternal(nint charaAddr, MyStatus status)
+    {
         MarkSynced(charaAddr);
         Character* chara = (Character*)charaAddr;
         if (chara == null)
@@ -362,16 +351,16 @@ public class IPCProcessor : IDisposable
             return;
         }
 
-        var status = MyStatus.FromTuple(data);
         if (!Utils.CheckWhitelistGlobal(status))
         {
             PluginLog.LogWarning($"[IPC] received apply request from {status.Applier} but failed whitelist check.");
             return;
         }
+
         var sm = chara->MyStatusManager();
         if (!sm.Ephemeral)
         {
-            PluginLog.LogDebug($"Adding or Updating remote Moodles : {data.Title}");
+            PluginLog.LogDebug($"Adding or Updating Remote Moodle {status.Title} to {chara->GetNameWithWorld()}");
             sm.AddOrUpdate(status.PrepareToApply(), UpdateSource.StatusTuple, false, true);
         }
     }

--- a/Moodles/Utils.cs
+++ b/Moodles/Utils.cs
@@ -57,6 +57,12 @@ public static unsafe partial class Utils
     public static bool CheckWhitelistGlobal(MyStatus status)
     {
         if(C.BroadcastAllowAll) return true;
+        
+        // If you apply a moodle to yourself via local plugins, it should continue through;
+        // Note that this adds an extra security hole in that any plugin can just say they're you.
+        // But that would be a problem is Party Permissions was on too, since you are always a member of you own party.
+        if (status.Applier == LocalPlayer.NameWithWorld) return true;
+
         bool permission = false;
         if(C.BroadcastAllowParty) permission = permission || UniversalParty.Members.Any(x => x.NameWithWorld == status.Applier);
         if(C.BroadcastAllowFriends) permission = permission || GetFriendlist().Contains(status.Applier);

--- a/Moodles/Utils.cs
+++ b/Moodles/Utils.cs
@@ -57,9 +57,10 @@ public static unsafe partial class Utils
     public static bool CheckWhitelistGlobal(MyStatus status)
     {
         if(C.BroadcastAllowAll) return true;
-        if(C.BroadcastAllowParty) return UniversalParty.Members.Any(x => x.NameWithWorld == status.Applier);
-        if(C.BroadcastAllowFriends) return GetFriendlist().Contains(status.Applier);
-        return false;
+        bool permission = false;
+        if(C.BroadcastAllowParty) permission = permission || UniversalParty.Members.Any(x => x.NameWithWorld == status.Applier);
+        if(C.BroadcastAllowFriends) permission = permission || GetFriendlist().Contains(status.Applier);
+        return permission;
     }
 
     public static List<string> GetFriendlist()


### PR DESCRIPTION
Heyo, a small PR that's more about visibility on three issues in the Permissions/White List area of IPCs, separated by commits.
1) Permissions flow control: currently broken; if you have Party Allowances on, it will never check your friends list.

2) Inconsistent permissions based on different IPC usages. Half of the IPCs didn't even use the White List. The second commit merges together the AddOrUpdateMoodleInternal functions into a single program flow. If this is unwanted, what is the difference between the IPCs, and why does one set have elevated permissions to apply moodles? Is it because the previous set of them that required a white list get their moodle data from the requesters payload? That might stop random moodles, but wouldn't stop someone spamming you with your own moodles.

3) This one is the most wishy washy. If a local plugin (not necessarily a sync) wants to apply a moodle that isn't in the local moodles directory with the IPC to the local player, how does it get permission to do it? I suggest a solution here of allowing moodles set by the local player to be pushed through the white list, but that allows a small security hole of "if a plugin wanted to, it could apply a moodle to you by sending your name as the sender", and it's basically impossible to differentiate between a good or bad one at that point. This security hole already exists if Party Permissions are toggled on, and could be filled with a 
`UniversalParty.Members.Any(x => x.NameWithWorld == status.Applier && x.NameWithWorld != LocalPlayer.NameWithWorld);`
but that still leaves the question of how to let local plugins use the IPC correctly, and if this security hole is even worth worrying about since Names as a pass code are extremely easily spoofed.